### PR TITLE
Update SnapshotDebugger to 2.0.8

### DIFF
--- a/2.2/alpine3.8/amd64/Dockerfile
+++ b/2.2/alpine3.8/amd64/Dockerfile
@@ -5,11 +5,12 @@ RUN apk update \
     && apk add libxml2 libuuid libunwind
 
 # Install Visual Studio Snapshot Debugger
-ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.1
-ARG VSSNAPSHOTDEBUGGER_SHA512=9d695d2ae9db2cf00cca429c798727563931743cfd7762e19002b397616e7a830f22d821b33a28550fa51152d7f55336bf284bf57aae03ada746605414be1c34
+ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.8
+ARG VSSNAPSHOTDEBUGGER_SHA512=1fecc5e198fcfd35a743f1245db0bdede68f3b2e65db1b808e7091151d46d8db106324a1fac4bcdaa3b5e38ac4e50cbcd8c1a488bbd2764ead8af24787f5b3dd
 RUN wget -O vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugger/release/${VSSNAPSHOTDEBUGGER_VERSION}/vssnapshotdebugger-${VSSNAPSHOTDEBUGGER_VERSION}-linux-musl-x64.tar.gz" \
     && echo "${VSSNAPSHOTDEBUGGER_SHA512}  vssnapshotdebugger.tar.gz" | sha512sum -c - \
     && mkdir -p /diag \
+    && mkdir -p /tmp/diag \
     && tar -pzxf vssnapshotdebugger.tar.gz -C /diag \
     && rm vssnapshotdebugger.tar.gz
 
@@ -26,8 +27,7 @@ ENV MicrosoftInstrumentationEngine_FileLogPath=/tmp/diag/log.txt
 RUN apk add bash unzip
 
 # Install Visual Studio Debugger
-ARG GETVSDBG_SHA512=fe76c7671951d2c0ba254c76d3fd7dc9f90cd329457e89bd277f099904b416578a6346d2b8e5d686f7e7f66463e8830e886cf869ef2d95b5a229324c6e15a649
-RUN wget -O getvsdbg.sh "https://aka.ms/vssnapshotdebugger/preview/getvsdbgsh" \
-    && echo "${GETVSDBG_SHA512}  getvsdbg.sh" | sha512sum -c - \
-    && bash ./getvsdbg.sh -v latest -l /diag/vsdbg \
+# Check the repo's README for vsdbg version compatibility with Visual Studio
+RUN wget -O getvsdbg.sh "https://aka.ms/getvsdbgsh" \
+    && bash ./getvsdbg.sh -v vs2017u5 -l /diag/vsdbg \
     && rm getvsdbg.sh

--- a/2.2/bionic/amd64/Dockerfile
+++ b/2.2/bionic/amd64/Dockerfile
@@ -6,11 +6,12 @@ RUN apt-get update \
         curl libxml2 uuid libunwind8
 
 # Install Visual Studio Snapshot Debugger
-ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.1
-ARG VSSNAPSHOTDEBUGGER_SHA512=58d417a6e1d09dc4acfa39dd2c1c801f73a147a3fd931c18daf9908fbeda877c307342497c049fd2864343958b5385c1cc31202ecfe6c8b0b16b64b07866310c
+ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.8
+ARG VSSNAPSHOTDEBUGGER_SHA512=18cc72ca2bdb291fb126b11ec705e270ad11e0b053010afb19d0252d3f2911a02af7496adf89eec883b9183771867b234902db6a02926ad1f0f736cba5e71e77
 RUN curl -SL --output vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugger/release/${VSSNAPSHOTDEBUGGER_VERSION}/vssnapshotdebugger-${VSSNAPSHOTDEBUGGER_VERSION}-linux-x64.tar.gz" \
     && echo "${VSSNAPSHOTDEBUGGER_SHA512}  vssnapshotdebugger.tar.gz" | sha512sum -c - \
     && mkdir -p /diag \
+    && mkdir -p /tmp/diag \
     && tar -pzxf vssnapshotdebugger.tar.gz -C /diag \
     && rm vssnapshotdebugger.tar.gz
 
@@ -28,10 +29,9 @@ RUN apt-get install -y --no-install-recommends \
         bash unzip
 
 # Install Visual Studio Debugger
-ARG GETVSDBG_SHA512=fe76c7671951d2c0ba254c76d3fd7dc9f90cd329457e89bd277f099904b416578a6346d2b8e5d686f7e7f66463e8830e886cf869ef2d95b5a229324c6e15a649
-RUN curl -SL --output getvsdbg.sh "https://aka.ms/vssnapshotdebugger/preview/getvsdbgsh" \
-    && echo "${GETVSDBG_SHA512}  getvsdbg.sh" | sha512sum -c - \
-    && bash ./getvsdbg.sh -v latest -l /diag/vsdbg \
+# Check the repo's README for version compatibility with Visual Studio
+RUN curl -SL --output getvsdbg.sh "https://aka.ms/getvsdbgsh" \
+    && bash ./getvsdbg.sh -v vs2017u5 -l /diag/vsdbg \
     && rm getvsdbg.sh
 
 # Remove package lists to save space; can be restored with 'apt-get update'

--- a/2.2/stretch-slim/amd64/Dockerfile
+++ b/2.2/stretch-slim/amd64/Dockerfile
@@ -6,11 +6,12 @@ RUN apt-get update \
         curl libxml2 uuid libunwind8
 
 # Install Visual Studio Snapshot Debugger
-ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.1
-ARG VSSNAPSHOTDEBUGGER_SHA512=58d417a6e1d09dc4acfa39dd2c1c801f73a147a3fd931c18daf9908fbeda877c307342497c049fd2864343958b5385c1cc31202ecfe6c8b0b16b64b07866310c
+ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.8
+ARG VSSNAPSHOTDEBUGGER_SHA512=18cc72ca2bdb291fb126b11ec705e270ad11e0b053010afb19d0252d3f2911a02af7496adf89eec883b9183771867b234902db6a02926ad1f0f736cba5e71e77
 RUN curl -SL --output vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugger/release/${VSSNAPSHOTDEBUGGER_VERSION}/vssnapshotdebugger-${VSSNAPSHOTDEBUGGER_VERSION}-linux-x64.tar.gz" \
     && echo "${VSSNAPSHOTDEBUGGER_SHA512}  vssnapshotdebugger.tar.gz" | sha512sum -c - \
     && mkdir -p /diag \
+    && mkdir -p /tmp/diag \
     && tar -pzxf vssnapshotdebugger.tar.gz -C /diag \
     && rm vssnapshotdebugger.tar.gz
 
@@ -28,10 +29,9 @@ RUN apt-get install -y --no-install-recommends \
         bash unzip
 
 # Install Visual Studio Debugger
-ARG GETVSDBG_SHA512=fe76c7671951d2c0ba254c76d3fd7dc9f90cd329457e89bd277f099904b416578a6346d2b8e5d686f7e7f66463e8830e886cf869ef2d95b5a229324c6e15a649
-RUN curl -SL --output getvsdbg.sh "https://aka.ms/vssnapshotdebugger/preview/getvsdbgsh" \
-    && echo "${GETVSDBG_SHA512}  getvsdbg.sh" | sha512sum -c - \
-    && bash ./getvsdbg.sh -v latest -l /diag/vsdbg \
+# Check the repo's README for version compatibility with Visual Studio
+RUN curl -SL --output getvsdbg.sh "https://aka.ms/getvsdbgsh" \
+    && bash ./getvsdbg.sh -v vs2017u5 -l /diag/vsdbg \
     && rm getvsdbg.sh
 
 # Remove package lists to save space; can be restored with 'apt-get update'

--- a/CHECKSUMS
+++ b/CHECKSUMS
@@ -1,3 +1,9 @@
+Version: 2.0.8
+Hash: SHA512
+
+18cc72ca2bdb291fb126b11ec705e270ad11e0b053010afb19d0252d3f2911a02af7496adf89eec883b9183771867b234902db6a02926ad1f0f736cba5e71e77  vssnapshotdebugger-2.0.8-linux-x64.tar.gz
+1fecc5e198fcfd35a743f1245db0bdede68f3b2e65db1b808e7091151d46d8db106324a1fac4bcdaa3b5e38ac4e50cbcd8c1a488bbd2764ead8af24787f5b3dd  vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz
+
 Version: 2.0.1
 Hash: SHA512
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,23 @@ applications without interupting them. Please see https://aka.ms/snappoint for m
 
 The Dockerfiles are organized according to the ASP.NET Core major and minor version, the OS platform, and the platform architecture.
 For example, the ASP.NET Core 2.2 Alpine 3.8 x64 Dockerfile is located at /2.2/alpine/amd64/Dockerfile. When built, this Dockerfile produces
-an image with Alpine 3.8 x64 as the base with ASP.NET Core 2.2 Runtime and the latest supported Snapshot Debugger backend package.
+an image with Alpine 3.8 x64 as the base with ASP.NET Core 2.2 Runtime and the latest supported Snapshot Debugger backend package and vsdbg package.
 
 The Dockerfiles do not take a dependency on the Docker build context, thus they can be built without specifying a build context when executing "docker build".
 
+### VsDbg Version Compatibility Table
+
+Pseudo-Version | Visual Studio Version
+:--------------|:-----------
+vs2017u5       | 2019
+
 ## Latest Release
 
-### Version: 2.0.1
+### Version: 2.0.8
 File Name | Description
 :---------|:-----------
-[vssnapshotdebugger-2.0.1-linux-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.1/vssnapshotdebugger-2.0.1-linux-x64.tar.gz) | For glibc based OS - most common
-[vssnapshotdebugger-2.0.1-linux-musl-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.1/vssnapshotdebugger-2.0.1-linux-musl-x64.tar.gz) | For musl based OS, such as Alpine Linux
+[vssnapshotdebugger-2.0.8-linux-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.8/vssnapshotdebugger-2.0.8-linux-x64.tar.gz) | For glibc based OS - most common
+[vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.8/vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz) | For musl based OS, such as Alpine Linux
 
 ### Additional Information
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,13 +8,19 @@ See [checksums](https://github.com/microsoft/vssnapshotdebugger-docker/blob/mast
 
 ## Latest Release
 
+### Version: 2.0.8
+File Name | Description
+:---------|:-----------
+[vssnapshotdebugger-2.0.8-linux-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.8/vssnapshotdebugger-2.0.8-linux-x64.tar.gz) | For glibc based OS - most common
+[vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.8/vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz) | For musl based OS, such as Alpine Linux
+
+## Previous Releases
+
 ### Version: 2.0.1
 File Name | Description
 :---------|:-----------
 [vssnapshotdebugger-2.0.1-linux-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.1/vssnapshotdebugger-2.0.1-linux-x64.tar.gz) | For glibc based OS - most common
 [vssnapshotdebugger-2.0.1-linux-musl-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.1/vssnapshotdebugger-2.0.1-linux-musl-x64.tar.gz) | For musl based OS, such as Alpine Linux
-
-## Previous Releases
 
 ### Version: 1.2.2
 File Name | Description

--- a/releases.json
+++ b/releases.json
@@ -38,5 +38,18 @@
             "uri": "https://aka.ms/vssnapshotdebugger/release/${Version}/vssnapshotdebugger-${Version}-linux-musl-x64.tar.gz",
             "sha512": "9d695d2ae9db2cf00cca429c798727563931743cfd7762e19002b397616e7a830f22d821b33a28550fa51152d7f55336bf284bf57aae03ada746605414be1c34"
         }]
+    },{
+        "version": "2.0.8",
+        "files": [{
+            "name": "vssnapshotdebugger-${Version}-linux-x64.tar.gz",
+            "description": "For glibc based OS - most common",
+            "uri": "https://aka.ms/vssnapshotdebugger/release/${Version}/vssnapshotdebugger-${Version}-linux-x64.tar.gz",
+            "sha512": "18cc72ca2bdb291fb126b11ec705e270ad11e0b053010afb19d0252d3f2911a02af7496adf89eec883b9183771867b234902db6a02926ad1f0f736cba5e71e77"
+        },{
+            "name": "vssnapshotdebugger-${Version}-linux-musl-x64.tar.gz",
+            "description": "For musl based OS, such as Alpine Linux",
+            "uri": "https://aka.ms/vssnapshotdebugger/release/${Version}/vssnapshotdebugger-${Version}-linux-musl-x64.tar.gz",
+            "sha512": "1fecc5e198fcfd35a743f1245db0bdede68f3b2e65db1b808e7091151d46d8db106324a1fac4bcdaa3b5e38ac4e50cbcd8c1a488bbd2764ead8af24787f5b3dd"
+        }]
     }]
 }

--- a/templates/README.md.template
+++ b/templates/README.md.template
@@ -15,9 +15,15 @@ applications without interupting them. Please see https://aka.ms/snappoint for m
 
 The Dockerfiles are organized according to the ASP.NET Core major and minor version, the OS platform, and the platform architecture.
 For example, the ASP.NET Core 2.2 Alpine 3.8 x64 Dockerfile is located at /2.2/alpine/amd64/Dockerfile. When built, this Dockerfile produces
-an image with Alpine 3.8 x64 as the base with ASP.NET Core 2.2 Runtime and the latest supported Snapshot Debugger backend package.
+an image with Alpine 3.8 x64 as the base with ASP.NET Core 2.2 Runtime and the latest supported Snapshot Debugger backend package and vsdbg package.
 
 The Dockerfiles do not take a dependency on the Docker build context, thus they can be built without specifying a build context when executing "docker build".
+
+### VsDbg Version Compatibility Table
+
+Pseudo-Version | Visual Studio Version
+:--------------|:-----------
+vs2017u5       | 2019
 
 ## Latest Release
 


### PR DESCRIPTION
* Depend on aka.ms/getvsdbgsh link and drop SHA512 check for vsdbg
* Use pseudo versioning
* Update SnapshotDebugger to v2.0.8
