### PR TITLE
Update SnapshotDebugger version to 2.0.16

### DIFF
--- a/2.2/alpine3.8/amd64/Dockerfile
+++ b/2.2/alpine3.8/amd64/Dockerfile
@@ -1,12 +1,12 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-alpine3.8
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine3.8
 
 # Install Visual Studio Snapshot Debugger prerequisites
 RUN apk update \
     && apk add libxml2 libuuid libunwind
 
 # Install Visual Studio Snapshot Debugger
-ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.8
-ARG VSSNAPSHOTDEBUGGER_SHA512=1fecc5e198fcfd35a743f1245db0bdede68f3b2e65db1b808e7091151d46d8db106324a1fac4bcdaa3b5e38ac4e50cbcd8c1a488bbd2764ead8af24787f5b3dd
+ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.16
+ARG VSSNAPSHOTDEBUGGER_SHA512=59f9406dbc397d6ca0dcb4f885c36f6c2d0ee28bee8386c11cf57dcae91fb4a04f625b72ce3949f5194dfad8c1b1e4c82edd09054a3f74304d4608476a3304d9
 RUN wget -O vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugger/release/${VSSNAPSHOTDEBUGGER_VERSION}/vssnapshotdebugger-${VSSNAPSHOTDEBUGGER_VERSION}-linux-musl-x64.tar.gz" \
     && echo "${VSSNAPSHOTDEBUGGER_SHA512}  vssnapshotdebugger.tar.gz" | sha512sum -c - \
     && mkdir -p /diag \
@@ -18,16 +18,14 @@ RUN wget -O vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugger/release
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={324F817A-7420-4E6D-B3C1-143FBED6D855}
 ENV CORECLR_PROFILER_PATH_64=/diag/Instrumentation64/libInstrumentationEngine.so
-ENV MicrosoftInstrumentationEngine_Host={CA487940-57D2-10BF-11B2-A3AD5A13CBC0}
-ENV MicrosoftInstrumentationEngine_HostPath_64=/diag/Instrumentation64/libMicrosoftExtensionsHost.so
 ENV MicrosoftInstrumentationEngine_FileLog=Errors
 ENV MicrosoftInstrumentationEngine_FileLogPath=/tmp/diag/log.txt
 
 # Install Visual Studio Debugger script prerequisites
-RUN apk add bash unzip
+RUN apk add unzip
 
 # Install Visual Studio Debugger
 # Check the repo's README for vsdbg version compatibility with Visual Studio
 RUN wget -O getvsdbg.sh "https://aka.ms/getvsdbgsh" \
-    && bash ./getvsdbg.sh -v vs2017u5 -l /diag/vsdbg \
+    && sh ./getvsdbg.sh -v vs2019 -l /diag/vsdbg \
     && rm getvsdbg.sh

--- a/2.2/alpine3.9/amd64/Dockerfile
+++ b/2.2/alpine3.9/amd64/Dockerfile
@@ -1,14 +1,13 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine3.9
 
 # Install Visual Studio Snapshot Debugger prerequisites
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        curl libxml2 uuid libunwind8
+RUN apk update \
+    && apk add libxml2 libuuid libunwind
 
 # Install Visual Studio Snapshot Debugger
 ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.16
-ARG VSSNAPSHOTDEBUGGER_SHA512=c4892f9779ab934167a44c3b94ef61e7c9aa5c4912911b0d3a63aa477369d0019d5ca6d80fdfd5e2ae0e917d1c0bb07311aabe1d00f15c9564a6ac26aa5569b4
-RUN curl -SL --output vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugger/release/${VSSNAPSHOTDEBUGGER_VERSION}/vssnapshotdebugger-${VSSNAPSHOTDEBUGGER_VERSION}-linux-x64.tar.gz" \
+ARG VSSNAPSHOTDEBUGGER_SHA512=59f9406dbc397d6ca0dcb4f885c36f6c2d0ee28bee8386c11cf57dcae91fb4a04f625b72ce3949f5194dfad8c1b1e4c82edd09054a3f74304d4608476a3304d9
+RUN wget -O vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugger/release/${VSSNAPSHOTDEBUGGER_VERSION}/vssnapshotdebugger-${VSSNAPSHOTDEBUGGER_VERSION}-linux-musl-x64.tar.gz" \
     && echo "${VSSNAPSHOTDEBUGGER_SHA512}  vssnapshotdebugger.tar.gz" | sha512sum -c - \
     && mkdir -p /diag \
     && mkdir -p /tmp/diag \
@@ -23,14 +22,10 @@ ENV MicrosoftInstrumentationEngine_FileLog=Errors
 ENV MicrosoftInstrumentationEngine_FileLogPath=/tmp/diag/log.txt
 
 # Install Visual Studio Debugger script prerequisites
-RUN apt-get install -y --no-install-recommends \
-    unzip
+RUN apk add unzip
 
 # Install Visual Studio Debugger
-# Check the repo's README for version compatibility with Visual Studio
-RUN curl -SL --output getvsdbg.sh "https://aka.ms/getvsdbgsh" \
+# Check the repo's README for vsdbg version compatibility with Visual Studio
+RUN wget -O getvsdbg.sh "https://aka.ms/getvsdbgsh" \
     && sh ./getvsdbg.sh -v vs2019 -l /diag/vsdbg \
     && rm getvsdbg.sh
-
-# Remove package lists to save space; can be restored with 'apt-get update'
-RUN rm -rf /var/lib/apt/lists/*

--- a/2.2/bionic/amd64/Dockerfile
+++ b/2.2/bionic/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic
 
 # Install Visual Studio Snapshot Debugger prerequisites
 RUN apt-get update \
@@ -6,8 +6,8 @@ RUN apt-get update \
         curl libxml2 uuid libunwind8
 
 # Install Visual Studio Snapshot Debugger
-ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.8
-ARG VSSNAPSHOTDEBUGGER_SHA512=18cc72ca2bdb291fb126b11ec705e270ad11e0b053010afb19d0252d3f2911a02af7496adf89eec883b9183771867b234902db6a02926ad1f0f736cba5e71e77
+ARG VSSNAPSHOTDEBUGGER_VERSION=2.0.16
+ARG VSSNAPSHOTDEBUGGER_SHA512=c4892f9779ab934167a44c3b94ef61e7c9aa5c4912911b0d3a63aa477369d0019d5ca6d80fdfd5e2ae0e917d1c0bb07311aabe1d00f15c9564a6ac26aa5569b4
 RUN curl -SL --output vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugger/release/${VSSNAPSHOTDEBUGGER_VERSION}/vssnapshotdebugger-${VSSNAPSHOTDEBUGGER_VERSION}-linux-x64.tar.gz" \
     && echo "${VSSNAPSHOTDEBUGGER_SHA512}  vssnapshotdebugger.tar.gz" | sha512sum -c - \
     && mkdir -p /diag \
@@ -19,19 +19,17 @@ RUN curl -SL --output vssnapshotdebugger.tar.gz "https://aka.ms/vssnapshotdebugg
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={324F817A-7420-4E6D-B3C1-143FBED6D855}
 ENV CORECLR_PROFILER_PATH_64=/diag/Instrumentation64/libInstrumentationEngine.so
-ENV MicrosoftInstrumentationEngine_Host={CA487940-57D2-10BF-11B2-A3AD5A13CBC0}
-ENV MicrosoftInstrumentationEngine_HostPath_64=/diag/Instrumentation64/libMicrosoftExtensionsHost.so
 ENV MicrosoftInstrumentationEngine_FileLog=Errors
 ENV MicrosoftInstrumentationEngine_FileLogPath=/tmp/diag/log.txt
 
 # Install Visual Studio Debugger script prerequisites
 RUN apt-get install -y --no-install-recommends \
-        bash unzip
+        unzip
 
 # Install Visual Studio Debugger
 # Check the repo's README for version compatibility with Visual Studio
 RUN curl -SL --output getvsdbg.sh "https://aka.ms/getvsdbgsh" \
-    && bash ./getvsdbg.sh -v vs2017u5 -l /diag/vsdbg \
+    && sh ./getvsdbg.sh -v vs2019 -l /diag/vsdbg \
     && rm getvsdbg.sh
 
 # Remove package lists to save space; can be restored with 'apt-get update'

--- a/CHECKSUMS
+++ b/CHECKSUMS
@@ -1,3 +1,9 @@
+Version: 2.0.16
+Hash: SHA512
+
+c4892f9779ab934167a44c3b94ef61e7c9aa5c4912911b0d3a63aa477369d0019d5ca6d80fdfd5e2ae0e917d1c0bb07311aabe1d00f15c9564a6ac26aa5569b4  vssnapshotdebugger-2.0.16-linux-x64.tar.gz
+59f9406dbc397d6ca0dcb4f885c36f6c2d0ee28bee8386c11cf57dcae91fb4a04f625b72ce3949f5194dfad8c1b1e4c82edd09054a3f74304d4608476a3304d9  vssnapshotdebugger-2.0.16-linux-musl-x64.tar.gz
+
 Version: 2.0.8
 Hash: SHA512
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ vs2017u5       | 2019
 
 ## Latest Release
 
-### Version: 2.0.8
+### Version: 2.0.16
 File Name | Description
 :---------|:-----------
-[vssnapshotdebugger-2.0.8-linux-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.8/vssnapshotdebugger-2.0.8-linux-x64.tar.gz) | For glibc based OS - most common
-[vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.8/vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz) | For musl based OS, such as Alpine Linux
+[vssnapshotdebugger-2.0.16-linux-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.16/vssnapshotdebugger-2.0.16-linux-x64.tar.gz) | For glibc based OS - most common
+[vssnapshotdebugger-2.0.16-linux-musl-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.16/vssnapshotdebugger-2.0.16-linux-musl-x64.tar.gz) | For musl based OS, such as Alpine Linux
 
 ### Additional Information
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,13 +8,19 @@ See [checksums](https://github.com/microsoft/vssnapshotdebugger-docker/blob/mast
 
 ## Latest Release
 
+### Version: 2.0.16
+File Name | Description
+:---------|:-----------
+[vssnapshotdebugger-2.0.16-linux-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.16/vssnapshotdebugger-2.0.16-linux-x64.tar.gz) | For glibc based OS - most common
+[vssnapshotdebugger-2.0.16-linux-musl-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.16/vssnapshotdebugger-2.0.16-linux-musl-x64.tar.gz) | For musl based OS, such as Alpine Linux
+
+## Previous Releases
+
 ### Version: 2.0.8
 File Name | Description
 :---------|:-----------
 [vssnapshotdebugger-2.0.8-linux-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.8/vssnapshotdebugger-2.0.8-linux-x64.tar.gz) | For glibc based OS - most common
 [vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz](https://aka.ms/vssnapshotdebugger/release/2.0.8/vssnapshotdebugger-2.0.8-linux-musl-x64.tar.gz) | For musl based OS, such as Alpine Linux
-
-## Previous Releases
 
 ### Version: 2.0.1
 File Name | Description

--- a/releases.json
+++ b/releases.json
@@ -51,5 +51,19 @@
             "uri": "https://aka.ms/vssnapshotdebugger/release/${Version}/vssnapshotdebugger-${Version}-linux-musl-x64.tar.gz",
             "sha512": "1fecc5e198fcfd35a743f1245db0bdede68f3b2e65db1b808e7091151d46d8db106324a1fac4bcdaa3b5e38ac4e50cbcd8c1a488bbd2764ead8af24787f5b3dd"
         }]
-    }]
+    },{
+        "version": "2.0.16",
+        "files": [{
+            "name": "vssnapshotdebugger-${Version}-linux-x64.tar.gz",
+            "description": "For glibc based OS - most common",
+            "uri": "https://aka.ms/vssnapshotdebugger/release/${Version}/vssnapshotdebugger-${Version}-linux-x64.tar.gz",
+            "sha512": "c4892f9779ab934167a44c3b94ef61e7c9aa5c4912911b0d3a63aa477369d0019d5ca6d80fdfd5e2ae0e917d1c0bb07311aabe1d00f15c9564a6ac26aa5569b4"
+        },{
+            "name": "vssnapshotdebugger-${Version}-linux-musl-x64.tar.gz",
+            "description": "For musl based OS, such as Alpine Linux",
+            "uri": "https://aka.ms/vssnapshotdebugger/release/${Version}/vssnapshotdebugger-${Version}-linux-musl-x64.tar.gz",
+            "sha512": "59f9406dbc397d6ca0dcb4f885c36f6c2d0ee28bee8386c11cf57dcae91fb4a04f625b72ce3949f5194dfad8c1b1e4c82edd09054a3f74304d4608476a3304d9"
+        }]
+    }
+    ]
 }

--- a/scripts/Common.psm1
+++ b/scripts/Common.psm1
@@ -61,7 +61,11 @@ function Format-ReleaseTokens() {
 
 function Get-ReleaseData() {
     $releasesPath = Join-Path -Path (Get-RepositoryRoot) -ChildPath "releases.json" -Resolve
-    return (Get-Content -Path $releasesPath -Raw | ConvertFrom-Json).releases
+    $releases = (Get-Content -Path $releasesPath -Raw | ConvertFrom-Json).releases
+    $releases | ForEach-Object {
+        $_.version = [System.Version]$_.version
+    }
+    return $releases
 }
 
 function Get-RepositoryRoot() {

--- a/scripts/UpdateDockerfiles.ps1
+++ b/scripts/UpdateDockerfiles.ps1
@@ -38,13 +38,13 @@ Get-ChildItem -Path "$repositoryRoot\$DotNetVersion" -Include Dockerfile -Recurs
     if (!$versionMatch.Success) {
         Write-Error "Unable to determine Snapshot Debugger version in Dockerfile '$dockerfileRelativePath'."
     }
-    $version = $versionMatch.Groups['Version'].Value
+    $version = [System.Version]$versionMatch.Groups['Version'].Value
 
     # Update Snapshot Debugger version
     if ($NewSnapshotDebuggerVersion) {
         Write-Verbose "Updating Snapshot Debugger version to ${NewSnapshotDebuggerVersion} in Dockerfile '$dockerfileRelativePath'."
         $content = $ArgVersionRegex.Replace($content, "${ArgVersionPrefix}${NewSnapshotDebuggerVersion}")
-        $version = $NewSnapshotDebuggerVersion
+        $version = [System.Version]$NewSnapshotDebuggerVersion
     }
 
     # Determine which release the Dockerfile is referencing


### PR DESCRIPTION
Change base images to use MCR.
Remove CLRIE Host environment variables.
Add Alpine 3.9 Dockerfile
Update debugger to use VS2019 compatible version.
Remove dependency on bash.
Update scripts to correctly sort releases.